### PR TITLE
Merge to Production

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # rpm-builder
 
+- displaylink
 - jq
 - yq

--- a/displaylink/displaylink.spec
+++ b/displaylink/displaylink.spec
@@ -58,9 +58,9 @@ BuildRequires:  systemd
 BuildRequires:  systemd-rpm-macros
 %endif
 
-%if 0%{?rhel}
-Requires: epel-release
-%endif
+# %if 0%{?rhel}
+# Requires: epel-release
+# %endif
 
 Requires:   dkms
 Requires:   %{kernel_pkg_name} >= 4.15, %{kernel_pkg_name}-devel >= 4.15


### PR DESCRIPTION
it is necessary to comment epel-release as the rpm build done in stream8 it makes it as required and it will not work with fedora's.


```
%if 0%{?rhel}
Requires: epel-release
%endif
```