### PR TITLE
chore: pin checkout@v4 and sibling actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore"
+      include: "scope"

--- a/.github/workflows/build-release-rpm.yml
+++ b/.github/workflows/build-release-rpm.yml
@@ -29,7 +29,7 @@ jobs:
     container:
       image: ghcr.io/platformfuzz/image-builder/stream8-rpmbuild:latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
       - name: Prepare environment
@@ -49,13 +49,13 @@ jobs:
           cd ./rpmbuild/
           rpmbuild --define "_topdir `pwd`" --ba ./SPECS/*.spec
       - name: Upload artifact
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: "${{ github.event.inputs.package }}"
           path: '**/*.rpm'
           retention-days: 1
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: |
             **/*.rpm

--- a/.github/workflows/test-build-rpm.yml
+++ b/.github/workflows/test-build-rpm.yml
@@ -25,7 +25,7 @@ jobs:
     container:
       image: ghcr.io/platformfuzz/image-builder/stream8-rpmbuild:latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: dev
       - name: Prepare environment
@@ -45,7 +45,7 @@ jobs:
           cd ./rpmbuild/
           rpmbuild --define "_topdir `pwd`" --ba ./SPECS/*.spec
       - name: Upload artifact
-        uses: actions/upload-artifact@v4.3.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: "${{ github.event.inputs.package }}"
           path: '**/*.rpm'


### PR DESCRIPTION
## Summary
- Replace floating `actions/checkout@v4` (and other floating actions in the same files) with SHA pins, or `actionsforge` reusables (`github-pages-deploy`, `astro-pages-deploy`, `validate-devschema`) where they fit
- Add Dependabot for `github-actions` when missing

## Test plan
- [ ] Required workflow checks pass
- [ ] Pages/deploy jobs still trigger as before (if applicable)